### PR TITLE
[fix] padding issue on Summary page

### DIFF
--- a/src/pages/SummaryStyled.ts
+++ b/src/pages/SummaryStyled.ts
@@ -32,7 +32,8 @@ export const LabelWrapper = styled.div`
 `;
 
 export const ValueWrapper = styled.div`
-  flex: 0 0 100px;
+  flex: 0 0 auto;
   text-align: left;
   padding-left: 10px;
+  white-space: nowrap;
 `;


### PR DESCRIPTION
Fixed padding issue on Summary page where long inputs would wrap to multiple lines instead of just expanding the width of their flexbox